### PR TITLE
Fee Calculation Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -1,4 +1,4 @@
-import { ISendTransaction, IUtxo, IVin, IVout } from './wallet';
+import { IOutput, ISendTransaction, IUtxo, IVin, IVout } from './wallet';
 import { BIP32Interface } from 'bip32';
 import { Psbt } from 'bitcoinjs-lib';
 import { Result } from '../utils';
@@ -26,6 +26,7 @@ export interface ISetupTransaction {
 	utxos?: IUtxo[]; // Used to pre-specify utxos to use
 	rbf?: boolean; // Enable or disable rbf
 	satsPerByte?: number; // Used to specify the fee rate in sats per vbyte
+	outputs?: IOutput[]; // Used to pre-specify outputs to use
 }
 
 export enum EFeeId {

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -176,14 +176,14 @@ export const constructByteCountParam = (
 	@param {TGetByteCountInputs} inputs
 	@param {TGetByteCountOutputs} outputs
 	@param {string} [message]
-	@param {number} [minByteCount=TRANSACTION_DEFAULTS.recommendedBaseFee] - The minimum byte count to return. Often helpful when calculating fees for a transaction that has not yet been constructed.
+	@param {number} [minByteCount=166] - The minimum byte count to return. Often helpful when calculating fees for a transaction that has not yet been constructed.
 	@returns {number}
 */
 export const getByteCount = (
 	inputs: TGetByteCountInputs,
 	outputs: TGetByteCountOutputs,
 	message?: string,
-	minByteCount = TRANSACTION_DEFAULTS.recommendedBaseFee
+	minByteCount = 166
 ): number => {
 	try {
 		// Base transaction weight
@@ -282,7 +282,7 @@ export const getByteCount = (
 
 		// Convert from Weight Units to virtual size
 		const totalVsize = Math.ceil(totalWeight / 4);
-		return totalVsize > minByteCount ? totalVsize : minByteCount;
+		return totalVsize < minByteCount ? minByteCount : totalVsize;
 	} catch {
 		return minByteCount;
 	}

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -86,7 +86,12 @@ import {
 } from '../shapes';
 import { Electrum } from '../electrum';
 import { Transaction } from '../transaction';
-import { CHUNK_LIMIT, GAP_LIMIT, GENERATE_ADDRESS_AMOUNT } from './constants';
+import {
+	CHUNK_LIMIT,
+	GAP_LIMIT,
+	GENERATE_ADDRESS_AMOUNT,
+	TRANSACTION_DEFAULTS
+} from './constants';
 import cloneDeep from 'lodash.clonedeep';
 import { btcToSats } from '../utils/conversion';
 import * as bip39 from 'bip39';
@@ -3231,6 +3236,9 @@ export class Wallet {
 	 */
 	public addTxInput({ input }: { input: IUtxo }): Result<IUtxo[]> {
 		try {
+			if (input.value <= TRANSACTION_DEFAULTS.dustLimit) {
+				return err('Input value is below dust limit.');
+			}
 			const txData = this.transaction.data;
 			const inputs = txData?.inputs ?? [];
 			const newInputs = [...inputs, input];

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -9,7 +9,7 @@ import {
 	generateMnemonic
 } from '../src';
 import { TEST_MNEMONIC } from './constants';
-import { deleteDirectory, getData, setData } from '../example/helpers';
+import { deleteDirectory, getData, servers, setData } from '../example/helpers';
 
 const expect = chai.expect;
 
@@ -29,6 +29,9 @@ before(async function () {
 		storage: {
 			getData,
 			setData
+		},
+		electrumOptions: {
+			servers: servers[EAvailableNetworks.testnet]
 		}
 	});
 	if (res.isErr()) {

--- a/tests/transaction.test.ts
+++ b/tests/transaction.test.ts
@@ -2,6 +2,7 @@ import * as chai from 'chai';
 import { decodeRawTransaction, Wallet } from '../';
 import { EAvailableNetworks } from '../src';
 import { TRANSACTION_TEST_MNEMONIC } from './constants';
+import { servers } from '../example/helpers';
 
 const expect = chai.expect;
 
@@ -13,7 +14,10 @@ before(async function () {
 	this.timeout(testTimeout);
 	const res = await Wallet.create({
 		mnemonic: TRANSACTION_TEST_MNEMONIC,
-		network: EAvailableNetworks.testnet
+		network: EAvailableNetworks.testnet,
+		electrumOptions: {
+			servers: servers[EAvailableNetworks.testnet]
+		}
 	});
 	if (res.isErr()) {
 		console.log('error: ', res.error.message);
@@ -41,9 +45,9 @@ describe('Transaction Test', async function (): Promise<void> {
 		if (feeInfo.isErr()) return;
 		expect(feeInfo).not.to.be.null;
 		expect(feeInfo.value.satsPerByte).to.equal(5);
-		expect(feeInfo.value.totalFee).to.equal(1280);
-		expect(feeInfo.value.transactionByteCount).to.equal(256);
-		expect(feeInfo.value.maxSatPerByte).to.equal(156);
+		expect(feeInfo.value.totalFee).to.equal(830);
+		expect(feeInfo.value.transactionByteCount).to.equal(166);
+		expect(feeInfo.value.maxSatPerByte).to.equal(240);
 	});
 
 	it('Should successfully create and decode a transaction.', async (): Promise<void> => {
@@ -59,19 +63,19 @@ describe('Transaction Test', async function (): Promise<void> {
 		expect(sendRes.isErr()).to.equal(false);
 		if (sendRes.isErr()) return;
 		expect(sendRes.value).to.equal(
-			'020000000001014b44d379e48a8100d1c26f7220b8bbf7a4894ff015d5bc4064a28d08d25d808d0000000000000000000288130000000000001600143f1a7a1802e377d01602acf1cad403368ed3bb89f81f010000000000160014a6bd95db4dd6979189cad389daad006e236f4ba8024730440220561a041d420e89ca3efbcabf5ed2831c1d562ea363e8a16b2637aeb845f59a8602201d8d403658da4ec010c2de2e1399e591383059abe593fb5aa7bd2480b00b6749012102e86b90924963237c59e5389aab1cc5350c114549d1c5e7186a56ef33aea24ff900000000'
+			'020000000001014b44d379e48a8100d1c26f7220b8bbf7a4894ff015d5bc4064a28d08d25d808d0000000000000000000288130000000000001600143f1a7a1802e377d01602acf1cad403368ed3bb89ba21010000000000160014a6bd95db4dd6979189cad389daad006e236f4ba802483045022100dd709b656c271c7e2ab4c83e0245b9b8d9096a1c7a33eddc9a32113f436851d9022033f8e5cb016ae4c440badfa34e438ada7bea2cdd36e782c136e516350b502bca012102e86b90924963237c59e5389aab1cc5350c114549d1c5e7186a56ef33aea24ff900000000'
 		);
 
 		const decodeRes = decodeRawTransaction(sendRes.value, wallet.network);
 		expect(decodeRes.isErr()).to.equal(false);
 		if (decodeRes.isErr()) return;
 		const expectedDecodeRes = {
-			txid: 'd0fd72cb4e16d025b65ddac64cc02d702955ce3c2d76dcb0276392fb35b4a644',
+			txid: '5afdbcb5ffa6e1104c4a67e80e8fde2280cb615b70b33c99951debc2d5e5f500',
 			tx_hash:
-				'80173ab787171855a84f568742f2fcce5456097bab27bfe654f339005584347c',
-			size: 222,
+				'094e314cbab1a268950a47216293d6ed170133ad265389e8dde7babf5eebed51',
+			size: 223,
 			vsize: 141,
-			weight: 561,
+			weight: 562,
 			version: 2,
 			locktime: 0,
 			vin: [
@@ -80,7 +84,7 @@ describe('Transaction Test', async function (): Promise<void> {
 					vout: 0,
 					scriptSig: { asm: '', hex: '' },
 					txinwitness: [
-						'30440220561a041d420e89ca3efbcabf5ed2831c1d562ea363e8a16b2637aeb845f59a8602201d8d403658da4ec010c2de2e1399e591383059abe593fb5aa7bd2480b00b674901',
+						'3045022100dd709b656c271c7e2ab4c83e0245b9b8d9096a1c7a33eddc9a32113f436851d9022033f8e5cb016ae4c440badfa34e438ada7bea2cdd36e782c136e516350b502bca01',
 						'02e86b90924963237c59e5389aab1cc5350c114549d1c5e7186a56ef33aea24ff9'
 					],
 					sequence: 0
@@ -97,7 +101,7 @@ describe('Transaction Test', async function (): Promise<void> {
 					}
 				},
 				{
-					value: 73720,
+					value: 74170,
 					n: 1,
 					scriptPubKey: {
 						asm: 'OP_0 a6bd95db4dd6979189cad389daad006e236f4ba8',
@@ -131,19 +135,19 @@ describe('Transaction Test', async function (): Promise<void> {
 		expect(sendManyRes.isErr()).to.equal(false);
 		if (sendManyRes.isErr()) return;
 		expect(sendManyRes.value).to.equal(
-			'020000000001014b44d379e48a8100d1c26f7220b8bbf7a4894ff015d5bc4064a28d08d25d808d000000000000000000038813000000000000160014a6b760eaa96a9ba91bae9465dfc4eabe711e1d6770170000000000001600146bcf920595e09b5d8f7b8d03b3694ad3057572898808010000000000160014a6bd95db4dd6979189cad389daad006e236f4ba802483045022100fefb3a9c8d08a24cc1d157f8d37a71d3f1ce32677af25186f292e37873bab32802207bae71c9b302a248ed5e0a86cfc14a433392f68ae1bd8f11ded3f73cc151dd27012102e86b90924963237c59e5389aab1cc5350c114549d1c5e7186a56ef33aea24ff900000000'
+			'020000000001014b44d379e48a8100d1c26f7220b8bbf7a4894ff015d5bc4064a28d08d25d808d000000000000000000038813000000000000160014a6b760eaa96a9ba91bae9465dfc4eabe711e1d6770170000000000001600146bcf920595e09b5d8f7b8d03b3694ad3057572892c0a010000000000160014a6bd95db4dd6979189cad389daad006e236f4ba80247304402207e7b5de41cb9bf33e434c2136390bf40d6b6552b69234a62f6bf48b89f0d44ac022056121c9a9d79d9d84896c9896a6fddb358b48667021ff2832b5c5871d90b701a012102e86b90924963237c59e5389aab1cc5350c114549d1c5e7186a56ef33aea24ff900000000'
 		);
 
 		const decodeRes = decodeRawTransaction(sendManyRes.value, wallet.network);
 		expect(decodeRes.isErr()).to.equal(false);
 		if (decodeRes.isErr()) return;
 		const expectedDecodeRes = {
-			txid: 'ac0ba26aff1b867b5372aba1ad50ba8087d09c0b6533ca66b2f0cca033b72272',
+			txid: '3fb40fc55d80c46d08f412c2c9a6b18e6b46264a6ae6fd4be8409480d1a53b45',
 			tx_hash:
-				'734db30a11ba7d6170c611932692bc70285a3fa9f85629ad59a3148d9e410c58',
-			size: 254,
+				'6b124dc403f6db7ce9c7967b8b3b5b3223d4df98626ece3b5d253450c47c9b88',
+			size: 253,
 			vsize: 172,
-			weight: 686,
+			weight: 685,
 			version: 2,
 			locktime: 0,
 			vin: [
@@ -152,7 +156,7 @@ describe('Transaction Test', async function (): Promise<void> {
 					vout: 0,
 					scriptSig: { asm: '', hex: '' },
 					txinwitness: [
-						'3045022100fefb3a9c8d08a24cc1d157f8d37a71d3f1ce32677af25186f292e37873bab32802207bae71c9b302a248ed5e0a86cfc14a433392f68ae1bd8f11ded3f73cc151dd2701',
+						'304402207e7b5de41cb9bf33e434c2136390bf40d6b6552b69234a62f6bf48b89f0d44ac022056121c9a9d79d9d84896c9896a6fddb358b48667021ff2832b5c5871d90b701a01',
 						'02e86b90924963237c59e5389aab1cc5350c114549d1c5e7186a56ef33aea24ff9'
 					],
 					sequence: 0
@@ -178,7 +182,7 @@ describe('Transaction Test', async function (): Promise<void> {
 					}
 				},
 				{
-					value: 67720,
+					value: 68140,
 					n: 2,
 					scriptPubKey: {
 						asm: 'OP_0 a6bd95db4dd6979189cad389daad006e236f4ba8',

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -22,7 +22,10 @@ before(async function () {
 	const res = await Wallet.create({
 		mnemonic: TEST_MNEMONIC,
 		network: EAvailableNetworks.testnet,
-		addressType: EAddressType.p2wpkh
+		addressType: EAddressType.p2wpkh,
+		electrumOptions: {
+			servers: servers[EAvailableNetworks.testnet]
+		}
 	});
 	if (res.isErr()) {
 		console.log('error: ', res.error.message);


### PR DESCRIPTION
This PR:
- Added `outputs` param to `setupTransaction` method.
- Updated `getByteCount`, `getTotalFee` & `getTotalFeeObj` methods.
- Setup additional dust limit checks to prevent users from adding inputs/outputs below the dust limit.
- Updated tests accordingly.
- Bumped version to `0.0.5` in `package.json`.