### PR TITLE
Remove onMessage conditions

### DIFF
--- a/src/electrum/index.ts
+++ b/src/electrum/index.ts
@@ -78,7 +78,7 @@ export class Electrum {
 		net?: Server;
 	}) {
 		this._wallet = wallet;
-		this.onMessage = wallet?.onMessage ?? ((): null => null);
+		this.onMessage = wallet.onMessage;
 		this.servers = servers ?? [];
 		this.network = network;
 		this.electrumNetwork = this.getElectrumNetwork(network);


### PR DESCRIPTION
This PR:
- Removes `onMessage` conditions.
- Updates `onMessage` type in `Wallet` class.
- Closes #21