### PR TITLE
Modify Error Conditions

### DIFF
--- a/src/electrum/index.ts
+++ b/src/electrum/index.ts
@@ -336,10 +336,9 @@ export class Electrum {
 
 			const responses = await Promise.all(promises);
 			responses.forEach((response) => {
-				if (response.error) {
-					return err('Unable to get address history.');
+				if (!response.error) {
+					combinedResponse.push(...response.data);
 				}
-				combinedResponse.push(...response.data);
 			});
 
 			const history: IGetAddressHistoryResponse[] = [];
@@ -518,8 +517,7 @@ export class Electrum {
 			}
 			const responses = await Promise.all(promises);
 			responses.forEach((response) => {
-				if (response.error) return err('Unable to get transactions.');
-				result.push(...response.data);
+				if (!response.error) result.push(...response.data);
 			});
 			return ok({
 				error: false,

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -445,7 +445,8 @@ export class Wallet {
 							walletData[key] = data as IOnchainFees;
 							break;
 						default:
-							return err(`Unhandled key in getWalletData: ${key}`);
+							console.log(`Unhandled key in getWalletData: ${key}`);
+							break;
 					}
 				})
 			);


### PR DESCRIPTION
This PR:
- Modifies error conditions in `getAddressHistory` & `getTransactions` methods.
    - We don't necessarily want to throw outright if we have an error in these responses since it's possible that a given transaction or some address history information has not yet propagated to the mempool of the node connected to the Electrum server.
- Addresses #20