### PR TITLE
Sweep Private Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ const txs = [
 	{ address: 'address3', amount: 3000 },
 ];
 const sendManyRes = await wallet.sendMany({ txs });
+
+// Sweep from a private key
+const sweepPrivateKeyRes = await wallet.sweepPrivateKey({
+	privateKey: 'privateKey',
+	toAddress: 'toAddress',
+	satsPerByte: 5,
+	broadcast: false
+});
 ```
 
 ## Documentation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/shapes/wallet.ts
+++ b/src/shapes/wallet.ts
@@ -131,3 +131,7 @@ export const defaultFeesShape: IOnchainFees = {
 	minimum: 1,
 	timestamp: Date.now() - 60 * 30 * 1000 - 1
 };
+
+export const getAddressTypes = (): EAddressType[] => {
+	return cloneDeep(Object.values(EAddressType));
+};

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -2,6 +2,7 @@ import { IOutput, ISendTransaction, IUtxo, IVin, IVout } from './wallet';
 import { BIP32Interface } from 'bip32';
 import { Psbt } from 'bitcoinjs-lib';
 import { Result } from '../utils';
+import { ECPairInterface } from 'ecpair';
 
 export interface ICreateTransaction {
 	transactionData?: ISendTransaction;
@@ -10,7 +11,7 @@ export interface ICreateTransaction {
 
 export interface IAddInput {
 	psbt: Psbt;
-	keyPair: BIP32Interface;
+	keyPair: BIP32Interface | ECPairInterface;
 	input: IUtxo;
 }
 

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -9,6 +9,8 @@ import {
 import { EFeeId } from './transaction';
 import { TLSSocket } from 'tls';
 import { Server } from 'net';
+import { ECPairInterface } from 'ecpair';
+import { BIP32Interface } from 'bip32';
 
 export type TAvailableNetworks = 'bitcoin' | 'testnet' | 'regtest';
 export type TAddressType = 'p2wpkh' | 'p2sh' | 'p2pkh';
@@ -65,6 +67,7 @@ export interface IUtxo {
 	tx_hash: string;
 	tx_pos: number;
 	value: number;
+	keyPair?: BIP32Interface | ECPairInterface;
 }
 
 export interface IVin {
@@ -252,17 +255,6 @@ export interface IGetAddressBalanceRes {
 	unconfirmed: number;
 }
 
-export interface IUtxo {
-	address: string;
-	index: number;
-	path: string;
-	scriptHash: string;
-	height: number;
-	tx_hash: string;
-	tx_pos: number;
-	value: number;
-}
-
 export interface IGenerateAddresses {
 	addressAmount?: number;
 	changeAddressAmount?: number;
@@ -286,6 +278,16 @@ export interface IGenerateAddressesResponse {
 export interface IGetAddressResponse {
 	address: string;
 	path: string;
+	publicKey: string;
+}
+
+export interface IGetAddressesFromPrivateKey {
+	keyPair: BIP32Interface | ECPairInterface;
+	addresses: IGetAddressesFromKeyPair[];
+}
+
+export interface IGetAddressesFromKeyPair {
+	address: string;
 	publicKey: string;
 }
 
@@ -501,4 +503,25 @@ export interface IBoostedTransaction {
 
 export interface IBoostedTransactions {
 	[txId: string]: IBoostedTransaction;
+}
+
+export interface IPrivateKeyInfo {
+	balance: number;
+	utxos: IUtxo[];
+	keyPair: ECPairInterface | BIP32Interface;
+	addresses: IGetAddressesFromKeyPair[];
+}
+
+export interface ISweepPrivateKey {
+	privateKey: string;
+	toAddress: string;
+	satsPerByte?: number;
+	broadcast?: boolean;
+	combineWithWalletUtxos?: boolean;
+}
+
+export interface ISweepPrivateKeyRes {
+	balance: number;
+	id: string;
+	hex: string;
 }

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -4,9 +4,9 @@ import { IAddress, IAddresses, Wallet } from '../';
 import {
 	EAddressType,
 	EAvailableNetworks,
+	generateMnemonic,
 	IGetUtxosResponse,
-	Result,
-	generateMnemonic
+	Result
 } from '../src';
 import { TEST_MNEMONIC } from './constants';
 import { servers } from '../example/helpers';
@@ -260,7 +260,10 @@ describe('Wallet Library', async function () {
 
 	it('Should successfully switch from regtest to mainnet', async () => {
 		expect(wallet.network).to.equal(EAvailableNetworks.regtest);
-		await wallet.switchNetwork(EAvailableNetworks.mainnet);
+		await wallet.switchNetwork(
+			EAvailableNetworks.mainnet,
+			servers[EAvailableNetworks.mainnet]
+		);
 		it('Should successfully create a wallet for the new network.', () => {
 			expect(wallet).not.to.be.null;
 		});


### PR DESCRIPTION
This PR:
- Made in loving memory of a colleague's friend.
- Adds `getPrivateKeyInfo` & `sweepPrivateKey` methods.
- Adds `getAddressFromKeyPair` & `getAddressesFromPrivateKey` methods.
- Updates `_getAddress` accordingly.
- Updates `addInput`, `signPsbt` & `createPsbtFromTransactionData` methods.
- Adds `addExternalInputs` method.
- Adds `sweepPrivateKey` example to `README.md`.
- Adds `sweepPrivateKey` tests to `transaction.test.ts`.
- Updates `getByteCount` to latest revision from source. 
- Adds `getAddressTypes` method.
- Bumps version to `0.0.11`.

Feature Summary:
- Adds ability to sweep private keys to a specified address.
- Adds ability to include external inputs to a given transaction.