### PR TITLE
Disable Messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/electrum/index.ts
+++ b/src/electrum/index.ts
@@ -51,7 +51,7 @@ try {
 
 export class Electrum {
 	private readonly _wallet: Wallet;
-	private onMessage: TOnMessage;
+	private sendMessage: TOnMessage;
 	private latestConnectionState: boolean | null = null;
 	private connectionPollingInterval: NodeJS.Timeout | null;
 	private tls: TLSSocket;
@@ -78,7 +78,7 @@ export class Electrum {
 		net?: Server;
 	}) {
 		this._wallet = wallet;
-		this.onMessage = wallet.onMessage;
+		this.sendMessage = wallet.sendMessage;
 		this.servers = servers ?? [];
 		this.network = network;
 		this.electrumNetwork = this.getElectrumNetwork(network);
@@ -674,7 +674,7 @@ export class Electrum {
 					const header: IHeader = { ...data[0], hash };
 					this._wallet.updateHeader(header);
 					this.onReceive?.(data);
-					this.onMessage(onMessageKeys.newBlock, data[0]);
+					this.sendMessage(onMessageKeys.newBlock, data[0]);
 				}
 			});
 		if (subscribeResponse.error) {
@@ -835,7 +835,7 @@ export class Electrum {
 			this.latestConnectionState !== isConnected &&
 			!this.wallet.isSwitchingNetworks
 		) {
-			this.onMessage('connectedToElectrum', isConnected);
+			this.sendMessage('connectedToElectrum', isConnected);
 			this.connectedToElectrum = isConnected;
 			this.latestConnectionState = isConnected;
 		}

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -203,6 +203,8 @@ export interface IWallet {
 	customGetScriptHash?: (data: ICustomGetScriptHash) => Promise<string>;
 	rbf?: boolean;
 	selectedFeeId?: EFeeId;
+	disableMessages?: boolean;
+	disableMessagesOnCreate?: boolean;
 }
 
 export interface IAddressData {


### PR DESCRIPTION
This PR:

Allows users to disable messages either on-start or at-will thereafter.

- Adds `disableMessages` & `disableMessagesOnCreate` params to `wallet` constructor params.
- Renames internal `onMessage` to `sendMessage`.
- Bumps version to `0.0.13` in `package.json`.