### PR TITLE
Monitor Specific Address Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,17 @@ const network = ENetworks.mainnet;
 // Use a specific address type. (Defaults to EAddressType.p2wpkh)
 const addressType = EAddressType.p2tr;
 
+// Monitor certain address types. (Defaults to Object.values(EAddressType))
+const addressTypesToMonitor = [EAddressType.p2tr, EAddressType.p2wpkh];
+
 // Subscribe to server messages (TOnMessage)
 const onMessage: TOnMessage = (id, data) => {
 	console.log(id);
 	console.dir(data, { depth: null });
 }
+
+// Disable startup messages. Messages resume once startup is complete. (Defaults to false)
+const disableMessagesOnCreate = true;
 
 // Persist sessions by getting and setting data from storage
 const storage: TStorage = {
@@ -144,7 +150,9 @@ const createWalletRes = await Wallet.create({
 	network,
 	onMessage,
 	storage, 
-    addressType
+    addressType,
+	addressTypesToMonitor,
+	disableMessagesOnCreate
 });
 if (createWalletRes.isErr()) return;
 const wallet = createWalletRes.value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beignet",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beignet",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/electrum/index.ts
+++ b/src/electrum/index.ts
@@ -1,5 +1,4 @@
 import {
-	EAddressType,
 	EAvailableNetworks,
 	IAddress,
 	IAddresses,
@@ -34,8 +33,8 @@ import * as electrum from 'rn-electrum-client/helpers';
 import { err, getAddressFromScriptPubKey, ok, Result, sleep } from '../utils';
 import { Wallet } from '../wallet';
 import { CHUNK_LIMIT, GAP_LIMIT } from '../wallet/constants';
-import { getScriptHash, objectKeys } from '../utils';
-import { addressTypes, POLLING_INTERVAL } from '../shapes';
+import { getScriptHash } from '../utils';
+import { POLLING_INTERVAL } from '../shapes';
 import { Block } from 'bitcoinjs-lib';
 import { onMessageKeys } from '../shapes';
 import { Server } from 'net';
@@ -277,7 +276,7 @@ export class Electrum {
 			const changeAddressIndexes = currentWallet.changeAddressIndex;
 
 			if (scriptHashes.length < 1) {
-				const addressTypeKeys = objectKeys(addressTypes);
+				const addressTypeKeys = this._wallet.addressTypesToMonitor;
 				addressTypeKeys.forEach((addressType) => {
 					const addresses = currentAddresses[addressType];
 					const changeAddresses = currentChangeAddresses[addressType];
@@ -426,7 +425,7 @@ export class Electrum {
 				});
 			const currentWallet = this._wallet.data;
 
-			const addressTypeKeys = Object.values(EAddressType);
+			const addressTypeKeys = this._wallet.addressTypesToMonitor;
 			let addresses = {} as IAddresses;
 			let changeAddresses = {} as IAddresses;
 			const existingUtxos: { [key: string]: IUtxo } = {};
@@ -712,7 +711,7 @@ export class Electrum {
 		onReceive?: (data: TSubscribedReceive) => void;
 	} = {}): Promise<Result<string>> {
 		const currentWallet = this._wallet.data;
-		const addressTypeKeys = objectKeys(addressTypes);
+		const addressTypeKeys = this._wallet.addressTypesToMonitor;
 		// Gather the receiving address scripthash for each address type if no scripthashes were provided.
 		if (!scriptHashes.length) {
 			for (const addressType of addressTypeKeys) {

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -205,6 +205,7 @@ export interface IWallet {
 	selectedFeeId?: EFeeId;
 	disableMessages?: boolean;
 	disableMessagesOnCreate?: boolean;
+	addressTypesToMonitor?: EAddressType[];
 }
 
 export interface IAddressData {


### PR DESCRIPTION
This PR:
- Allows users to monitor specific address types instead of every type in `EAddressTypes`.
- Adds `addressTypesToMonitor` to `Wallet` class.
- Updates `README.md`.
- Bumps version to `0.0.18`.