### PR TITLE
Adds gapLimitOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/types/electrum.ts
+++ b/src/types/electrum.ts
@@ -30,6 +30,13 @@ export enum EProtocol {
 	ssl = 'ssl'
 }
 
+export enum EScanningStrategy {
+	all = 'all', // Scan all addresses/scripthashes
+	gapLimit = 'gapLimit', // Adhere to the gap limit within range of the provided index when scanning addresses/scripthashes. If higher than the current index, it will be ignored
+	startingIndex = 'startingIndex', // Scan all addresses/scripthashes starting from the provided index. If higher than the current index, it will be ignored
+	singleIndex = 'singleIndex' // Scan the single provided address/scripthash
+}
+
 export interface IGetUtxosResponse {
 	utxos: IUtxo[];
 	balance: number;

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -58,3 +58,8 @@ export type TGetTotalFeeObj = {
 	satsPerByte: number;
 	maxSatPerByte: number; // Max sats per byte that can be used for a given transaction without exceeding 50% of the balance.
 };
+
+export type TGapLimitOptions = {
+	lookAhead: number;
+	lookBehind: number;
+};

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -6,7 +6,7 @@ import {
 	TServer,
 	TTxResult
 } from './electrum';
-import { EFeeId } from './transaction';
+import { EFeeId, TGapLimitOptions } from './transaction';
 import { TLSSocket } from 'tls';
 import { Server } from 'net';
 import { ECPairInterface } from 'ecpair';
@@ -67,6 +67,7 @@ export interface IUtxo {
 	tx_hash: string;
 	tx_pos: number;
 	value: number;
+	publicKey: string;
 	keyPair?: BIP32Interface | ECPairInterface;
 }
 
@@ -207,6 +208,9 @@ export interface IWallet {
 	disableMessages?: boolean;
 	disableMessagesOnCreate?: boolean;
 	addressTypesToMonitor?: EAddressType[];
+	gapLimitOptions?: TGapLimitOptions;
+	addressLookBehind?: number;
+	addressLookAhead?: number;
 }
 
 export interface IAddressData {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -331,3 +331,17 @@ export const sleep = (ms): Promise<void> => {
 		setTimeout(resolve, ms);
 	});
 };
+
+/**
+ * Returns the difference between two address indexes.
+ * @param addrIndex1
+ * @param addrIndex2
+ * @returns number
+ */
+export const getAddressIndexDiff = (addrIndex1 = 0, addrIndex2 = 0): number => {
+	if (addrIndex1 < 0) addrIndex1 = -1;
+	if (addrIndex2 < 0) addrIndex2 = -1;
+	return Math.abs(addrIndex1 - addrIndex2);
+};
+
+export const isPositive = (num: number): boolean => num > 0;

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -11,6 +11,7 @@ import {
 	ITxHashes,
 	IWalletData,
 	ObjectKeys,
+	TGapLimitOptions,
 	TGetData,
 	TKeyDerivationPurpose
 } from '../types';
@@ -26,6 +27,7 @@ import {
 	WALLET_ID_PREFIX,
 	BITKIT_WALLET_SEED_HASH_PREFIX
 } from '../wallet/constants';
+import { getAddressIndexDiff } from './helpers';
 
 /**
  * Returns the default wallet data object.
@@ -349,3 +351,74 @@ export const getTxFee = ({
 	satsPerByte: number;
 	transactionByteCount: number;
 }): number => transactionByteCount * satsPerByte;
+
+export const filterAddressesForGapLimit = ({
+	addresses,
+	index,
+	gapLimitOptions
+}: {
+	addresses: IAddress[];
+	index: number;
+	gapLimitOptions: TGapLimitOptions;
+}): IAddress[] => {
+	const { lookBehind, lookAhead } = gapLimitOptions;
+	return addresses.filter((a) => {
+		if (a.index >= index) {
+			return getAddressIndexDiff(index, a.index) <= lookAhead;
+		}
+		return getAddressIndexDiff(index, a.index) <= lookBehind;
+	});
+};
+
+export const filterAddressesObjForGapLimit = ({
+	addresses,
+	index,
+	gapLimitOptions
+}: {
+	addresses: IAddresses;
+	index: number;
+	gapLimitOptions: TGapLimitOptions;
+}): IAddresses => {
+	const { lookBehind, lookAhead } = gapLimitOptions;
+	const response: IAddresses = {};
+	Object.values(addresses).map((a) => {
+		if (a.index >= index) {
+			if (getAddressIndexDiff(a.index, index) <= lookAhead) {
+				response[a.scriptHash] = a;
+			}
+		} else {
+			if (getAddressIndexDiff(a.index, index) <= lookBehind) {
+				response[a.scriptHash] = a;
+			}
+		}
+	});
+	return response;
+};
+
+export const filterAddressesObjForStartingIndex = ({
+	addresses,
+	index
+}: {
+	addresses: IAddresses;
+	index: number;
+}): IAddresses => {
+	const response: IAddresses = {};
+	Object.values(addresses).map((a) => {
+		if (a.index >= index) response[a.scriptHash] = a;
+	});
+	return response;
+};
+
+export const filterAddressesObjForSingleIndex = ({
+	addresses,
+	addressIndex
+}: {
+	addresses: IAddresses;
+	addressIndex: number;
+}): IAddresses => {
+	const response: IAddresses = {};
+	Object.values(addresses).map((a) => {
+		if (a.index === addressIndex) response[a.scriptHash] = a;
+	});
+	return response;
+};


### PR DESCRIPTION
This PR:
- Adds ability to adjust gap limit `lookBehind` and `lookAhead`.
- Implements multiple scanning strategies for `getUtxos` method.
- Ensures we continue monitoring addresses with UTXO's outside the gap limit in the event it receives additional Bitcoin.
- Updates `getNextAvailableAddress` method to account for aforementioned changes.
- Adds tests for `gapLimitOptions`.
- Bumps version to `0.0.23`.