### PR TITLE
Upgrades rn-electrum-client to 0.0.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beignet",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beignet",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "1.0.5",
@@ -20,7 +20,7 @@
         "ecpair": "2.1.0",
         "lodash.clonedeep": "4.5.0",
         "net": "1.0.2",
-        "rn-electrum-client": "0.0.11"
+        "rn-electrum-client": "^0.0.12"
       },
       "devDependencies": {
         "@types/chai": "4.3.0",
@@ -2457,9 +2457,9 @@
       }
     },
     "node_modules/rn-electrum-client": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/rn-electrum-client/-/rn-electrum-client-0.0.11.tgz",
-      "integrity": "sha512-XfpUPyWf+/Bqcc67DmvBvCtlzc/FLaCSikOrUtFaba6zunWDCmXRgNNtvHQEoC40FrfDIo1bh8wv4oymyx+2xg==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/rn-electrum-client/-/rn-electrum-client-0.0.12.tgz",
+      "integrity": "sha512-vaRcZR9zxPo66MhSZcjlnEFmb3FqTMj/OrQpvA+eW2xMpmINoLGUd/jLX+MiHxbci5haom5c6NYVvzK9Ongxdw==",
       "engines": {
         "node": ">=6"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {
@@ -47,7 +47,7 @@
     "ecpair": "2.1.0",
     "lodash.clonedeep": "4.5.0",
     "net": "1.0.2",
-    "rn-electrum-client": "0.0.11"
+    "rn-electrum-client": "^0.0.12"
   },
   "devDependencies": {
     "@types/chai": "4.3.0",

--- a/src/electrum/index.ts
+++ b/src/electrum/index.ts
@@ -232,7 +232,7 @@ export class Electrum {
 					network: this.electrumNetwork
 				});
 			if (unspentAddressResult.error) {
-				return err(unspentAddressResult.error);
+				return err(unspentAddressResult.data);
 			}
 			let balance = 0;
 			const utxos: IUtxo[] = [];
@@ -687,6 +687,7 @@ export class Electrum {
 			if (response && !response.error) {
 				return ok(response);
 			} else {
+				if (response?.error?.message) return err(response.error.message);
 				return err(response ?? 'Unable to get transactions from inputs.');
 			}
 		} catch (e) {


### PR DESCRIPTION
- Upgrades `rn-electrum-client` to 0.0.12.
- Updates error response in `listUnspentAddressScriptHashes`. 
- Updates error response in `getTransactionsFromInputs`.
- Bumps version to `0.0.24`.