### PR TITLE
Fix Scanning Strategies in getUtxos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beignet",
-  "version": "0.0.23",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beignet",
-      "version": "0.0.23",
+      "version": "0.0.25",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "1.0.5",
@@ -20,7 +20,7 @@
         "ecpair": "2.1.0",
         "lodash.clonedeep": "4.5.0",
         "net": "1.0.2",
-        "rn-electrum-client": "^0.0.12"
+        "rn-electrum-client": "^0.0.15"
       },
       "devDependencies": {
         "@types/chai": "4.3.0",
@@ -2457,9 +2457,9 @@
       }
     },
     "node_modules/rn-electrum-client": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/rn-electrum-client/-/rn-electrum-client-0.0.12.tgz",
-      "integrity": "sha512-vaRcZR9zxPo66MhSZcjlnEFmb3FqTMj/OrQpvA+eW2xMpmINoLGUd/jLX+MiHxbci5haom5c6NYVvzK9Ongxdw==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/rn-electrum-client/-/rn-electrum-client-0.0.15.tgz",
+      "integrity": "sha512-C7AJ+TWGUz7jPHJo/hmzfgS/VhHT3hNMtfuujwLmsN4XYF06yzPiRocWvY4MvzOg40MHgo+5lpcOwVn0uLVOqg==",
       "engines": {
         "node": ">=6"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {
@@ -47,7 +47,7 @@
     "ecpair": "2.1.0",
     "lodash.clonedeep": "4.5.0",
     "net": "1.0.2",
-    "rn-electrum-client": "^0.0.12"
+    "rn-electrum-client": "^0.0.15"
   },
   "devDependencies": {
     "@types/chai": "4.3.0",

--- a/src/electrum/index.ts
+++ b/src/electrum/index.ts
@@ -467,55 +467,76 @@ export class Electrum {
 					changeAddresses = { ...changeAddresses, ...allChangeAddresses };
 				} else {
 					// Grab the current index for address/change addresses if none were provided.
-					if (!addressIndex)
-						addressIndex = currentWallet.addressIndex[addressType].index;
-					if (!changeAddressIndex)
-						changeAddressIndex =
-							currentWallet.changeAddressIndex[addressType].index;
+					const _addressIndex =
+						addressIndex === undefined
+							? currentWallet.addressIndex[addressType].index
+							: addressIndex;
+					const _changeAddressIndex =
+						changeAddressIndex === undefined
+							? currentWallet.changeAddressIndex[addressType].index
+							: changeAddressIndex;
 
 					// Use the lowest index to ensure we're not starting above our current index.
 					// TODO: Consider removing this entirely or at least updating it to allow up to the max stored address/change address index.
 					const lowestAddressIndex = Math.min(
-						addressIndex,
+						_addressIndex,
 						currentWallet.addressIndex[addressType].index
 					);
 					const lowestChangeAddressIndex = Math.min(
-						changeAddressIndex,
+						_changeAddressIndex,
 						currentWallet.changeAddressIndex[addressType].index
 					);
 
 					switch (scanningStrategy) {
 						case EScanningStrategy.gapLimit:
-							addresses = filterAddressesObjForGapLimit({
-								addresses: allAddresses,
-								index: lowestAddressIndex,
-								gapLimitOptions: this._wallet.gapLimitOptions
-							});
-							changeAddresses = filterAddressesObjForGapLimit({
-								addresses: allChangeAddresses,
-								index: lowestChangeAddressIndex,
-								gapLimitOptions: this._wallet.gapLimitOptions
-							});
+							addresses = {
+								...addresses,
+								...filterAddressesObjForGapLimit({
+									addresses: allAddresses,
+									index: lowestAddressIndex,
+									gapLimitOptions: this._wallet.gapLimitOptions
+								})
+							};
+							changeAddresses = {
+								...changeAddresses,
+								...filterAddressesObjForGapLimit({
+									addresses: allChangeAddresses,
+									index: lowestChangeAddressIndex,
+									gapLimitOptions: this._wallet.gapLimitOptions
+								})
+							};
 							break;
 						case EScanningStrategy.startingIndex:
-							addresses = filterAddressesObjForStartingIndex({
-								addresses: allAddresses,
-								index: lowestAddressIndex
-							});
-							changeAddresses = filterAddressesObjForStartingIndex({
-								addresses: allChangeAddresses,
-								index: lowestChangeAddressIndex
-							});
+							addresses = {
+								...addresses,
+								...filterAddressesObjForStartingIndex({
+									addresses: allAddresses,
+									index: lowestAddressIndex
+								})
+							};
+							changeAddresses = {
+								...changeAddresses,
+								...filterAddressesObjForStartingIndex({
+									addresses: allChangeAddresses,
+									index: lowestChangeAddressIndex
+								})
+							};
 							break;
 						case EScanningStrategy.singleIndex:
-							addresses = filterAddressesObjForSingleIndex({
-								addresses: allAddresses,
-								addressIndex
-							});
-							changeAddresses = filterAddressesObjForSingleIndex({
-								addresses: allChangeAddresses,
-								addressIndex: changeAddressIndex
-							});
+							addresses = {
+								...addresses,
+								...filterAddressesObjForSingleIndex({
+									addresses: allAddresses,
+									addressIndex: _addressIndex
+								})
+							};
+							changeAddresses = {
+								...changeAddresses,
+								...filterAddressesObjForSingleIndex({
+									addresses: allChangeAddresses,
+									addressIndex: _changeAddressIndex
+								})
+							};
 							break;
 					}
 				}

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -255,7 +255,7 @@ export class Wallet {
 	public async switchNetwork(
 		network: EAvailableNetworks,
 		servers?: TServer | TServer[]
-	): Promise<Result<string>> {
+	): Promise<Result<Wallet>> {
 		this.isSwitchingNetworks = true;
 		// Disconnect from Electrum.
 		await this.electrum.disconnect();
@@ -283,7 +283,7 @@ export class Wallet {
 		Object.assign(this, createRes.value);
 		await this.updateFeeEstimates(true);
 		this.isSwitchingNetworks = false;
-		return ok(`Successfully switched to ${network}.`);
+		return ok(this);
 	}
 
 	/**


### PR DESCRIPTION
This PR:
- Fixes scanning strategies in `getUtxos`.
- Bumps `rn-electrum-client` to version `0.0.15`.
- Updates `switchNetwork` method to return `Wallet`.
- Bumps `beignet` version to `0.0.25`.