### PR TITLE
Ignore Gap Limit When Generating Addresses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beignet",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beignet",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This PR:
- Adds `overrideGapLimit` param to `generateNewReceiveAddress` method for users/devs that need to exceed the previously set/standard gap limit when generating addresses.
- Bumps version to `0.0.29`.