### PR TITLE
Adds batchLimit check to listUnspentAddressScriptHashes

### DIFF
--- a/src/types/electrum.ts
+++ b/src/types/electrum.ts
@@ -183,3 +183,26 @@ export type ElectrumConnectionSubscription = {
 };
 
 export type TGetAddressHistory = { txid: string; height: number };
+
+export type TUnspentAddressScriptHash = {
+	height: number;
+	tx_hash: string;
+	tx_pos: number;
+	value: number;
+};
+
+export type TUnspentAddressScriptHashResult = {
+	id: number;
+	jsonrpc: string;
+	result: TUnspentAddressScriptHash[];
+	param: string;
+	data: IAddress;
+};
+
+export type TUnspentAddressScriptHashResponse = {
+	id: number;
+	error: boolean;
+	method: string;
+	data: TUnspentAddressScriptHashResult[];
+	network: string;
+};

--- a/src/utils/electrum.ts
+++ b/src/utils/electrum.ts
@@ -6,6 +6,7 @@ import {
 	EElectrumNetworks,
 	ElectrumConnectionPubSub,
 	ElectrumConnectionSubscription,
+	IAddresses,
 	IFormattedPeerData,
 	TProtocol
 } from '../types';
@@ -206,4 +207,27 @@ export const getElectrumNetwork = (
 		default:
 			return EElectrumNetworks.bitcoinTestnet;
 	}
+};
+
+/**
+ * Splits the addresses into chunks of the specified batch limit.
+ * @param {IAddresses} addresses
+ * @param {number} batchLimit
+ * @returns {IAddresses[]}
+ */
+export const splitAddresses = (
+	addresses: IAddresses,
+	batchLimit: number
+): IAddresses[] => {
+	const chunks: IAddresses[] = [];
+	const scriptHashes = Object.keys(addresses);
+	for (let i = 0; i < scriptHashes.length; i += batchLimit) {
+		const chunk: IAddresses = {};
+		const chunkScriptHashes = scriptHashes.slice(i, i + batchLimit);
+		for (const scriptHash of chunkScriptHashes) {
+			chunk[scriptHash] = addresses[scriptHash];
+		}
+		chunks.push(chunk);
+	}
+	return chunks;
 };


### PR DESCRIPTION
This PR:
- Adds `batchLimit` check to `listUnspentAddressScriptHashes` method.
- Creates `TUnspentAddressScriptHash`, `TUnspentAddressScriptHashResult` & `TUnspentAddressScriptHashResponse` Electrum types.
- Creates `splitAddresses` helper method to electrum utils.