### PR TITLE
Fix vout Error For Larger Txs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beignet",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beignet",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This PR:
- Adds error check to `getInputData` to resolve the `vout` error for transactions containing 3000+ inputs.
    - If triggered the warning is logged and suggested that the user increase the limits on their Electrum server.
- Attempt to re-run any failed `inputData` requests.
- Bump version to `0.0.36`.