### PR TITLE
chore: update to work with new react-native-tcp-socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ const sendMaxRes = await wallet.sendMax({ address: 'address to send sats to', sa
 
 ```typescript
 import { Wallet, generateMnemonic } from 'beignet';
+import net from 'net'
+import tls from 'tls'
 import { TStorage } from './wallet';
 
 // Generate a mnemonic phrase
@@ -152,7 +154,11 @@ const storage: TStorage = {
 const createWalletRes = await Wallet.create({
 	mnemonic,
 	passphrase,
-	electrumOptions: { servers },
+	electrumOptions: {
+		servers,
+		net,
+		tls
+	},
 	network,
 	onMessage,
 	storage, 
@@ -187,6 +193,17 @@ const history = await wallet.getAddressHistory('address');
 
 // Get transaction details for a given transaction id. TTxDetails
 const txDetails = await wallet.getTransactionDetails('txid');
+```
+
+## React Native
+
+You can use `react-native-tcp-socket` as a drop in replacement for `net` & `tls` in a react-native environment. In `package.json`:
+
+```json
+"react-native": {
+	"net": "react-native-tcp-socket",
+	"tls": "react-native-tcp-socket"
+}
 ```
 
 ## Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ecpair": "2.1.0",
         "lodash.clonedeep": "4.5.0",
         "net": "1.0.2",
-        "rn-electrum-client": "0.0.17"
+        "rn-electrum-client": "0.0.18"
       },
       "devDependencies": {
         "@types/chai": "4.3.0",
@@ -2458,9 +2458,9 @@
       }
     },
     "node_modules/rn-electrum-client": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/rn-electrum-client/-/rn-electrum-client-0.0.17.tgz",
-      "integrity": "sha512-HeCcVqw7dB6THrFZNVUlc2hzFL6WHyKWBbkeTgDYam8DOUGwS72GPgn9OMH1nz7qTWMx0FaIN9H0ny4kFUuJgg==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/rn-electrum-client/-/rn-electrum-client-0.0.18.tgz",
+      "integrity": "sha512-g4uORu0lH3pifLo8T3OfXwXLn5fJhin9UmkfURCfMTnjBLClbPkd7vCqr+aYGmXHjGuaXplTPIEIOkcDUj15aw==",
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:check": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --fix --ext .js,.jsx,.ts,.tsx",
+    "tsc:check": "tsc -p tsconfig.json --noEmit",
     "build": "tsc",
     "docs:markdown": "npx typedoc --plugin typedoc-plugin-markdown --out docs/markdown src/index.ts",
     "docs:html": "npx typedoc --out docs/html",
@@ -47,7 +48,7 @@
     "ecpair": "2.1.0",
     "lodash.clonedeep": "4.5.0",
     "net": "1.0.2",
-    "rn-electrum-client": "0.0.17"
+    "rn-electrum-client": "0.0.18"
   },
   "devDependencies": {
     "@types/chai": "4.3.0",

--- a/src/types/electrum.ts
+++ b/src/types/electrum.ts
@@ -6,6 +6,9 @@ import {
 	IUtxo
 } from './wallet';
 
+export type Net = typeof import('net');
+export type Tls = typeof import('tls');
+
 export type TElectrumNetworks = 'bitcoin' | 'bitcoinTestnet' | 'bitcoinRegtest';
 export enum EElectrumNetworks {
 	bitcoin = 'bitcoin',

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -3,12 +3,12 @@ import {
 	EElectrumNetworks,
 	IHeader,
 	INewBlock,
+	Net,
 	TServer,
-	TTxResult
+	TTxResult,
+	Tls
 } from './electrum';
 import { EFeeId, TGapLimitOptions } from './transaction';
-import { TLSSocket } from 'tls';
-import { Server } from 'net';
 import { ECPairInterface } from 'ecpair';
 import { BIP32Interface } from 'bip32';
 
@@ -190,10 +190,10 @@ export interface IWallet {
 	addressType?: EAddressType;
 	data?: IWalletData;
 	storage?: TStorage;
-	electrumOptions?: {
+	electrumOptions: {
+		net: Net;
+		tls: Tls;
 		servers?: TServer | TServer[];
-		tls?: TLSSocket;
-		net?: Server;
 		batchLimit?: number; // Maximum number of requests to be sent in a single batch
 		batchDelay?: number; // Delay (in milliseconds) between each batch of requests
 	};

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -46,12 +46,14 @@ import {
 	IVout,
 	IWallet,
 	IWalletData,
+	Net,
 	TAddressIndexInfo,
 	TAddressTypeContent,
 	TAvailableNetworks,
 	TGapLimitOptions,
 	TGetData,
 	TGetTotalFeeObj,
+	Tls,
 	TMessageDataMap,
 	TOnMessage,
 	TProcessUnconfirmedTransactions,
@@ -107,8 +109,6 @@ import { GAP_LIMIT, TRANSACTION_DEFAULTS } from './constants';
 import cloneDeep from 'lodash.clonedeep';
 import { btcToSats } from '../utils/conversion';
 import * as bip39 from 'bip39';
-import { TLSSocket } from 'tls';
-import { Server } from 'net';
 
 const bip32 = BIP32Factory(ecc);
 
@@ -138,9 +138,9 @@ export class Wallet {
 	public readonly id: string;
 	public readonly name: string;
 	public electrumOptions?: {
+		net: Net;
+		tls: Tls;
 		servers?: TServer | TServer[];
-		tls?: TLSSocket;
-		net?: Server;
 		batchLimit?: number; // Maximum number of requests to be sent in a single batch
 		batchDelay?: number; // Delay (in milliseconds) between each batch of requests
 	};
@@ -160,7 +160,7 @@ export class Wallet {
 		network = EAvailableNetworks.mainnet,
 		addressType = EAddressType.p2wpkh,
 		storage,
-		electrumOptions = {},
+		electrumOptions,
 		onMessage = (): null => null,
 		customGetAddress,
 		customGetScriptHash,


### PR DESCRIPTION
- update `rn-electrum-client` to `0.0.18`
- `net` & `tls` implementation now has to be passed in application code
- add instructions for usage in react-native