### PR TITLE
test: fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ lerna-debug.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Tests
+example/walletData

--- a/example/helpers.ts
+++ b/example/helpers.ts
@@ -64,7 +64,14 @@ export const servers = {
 			protocol: EProtocol.ssl
 		}
 	],
-	[EAvailableNetworks.testnet]: [],
+	[EAvailableNetworks.testnet]: [
+		{
+			host: 'testnet.aranguren.org',
+			ssl: 51002,
+			tcp: 51001,
+			protocol: EProtocol.tcp,
+		}
+	],
 	[EAvailableNetworks.regtest]: [
 		{
 			host: '35.233.47.252',

--- a/src/electrum/constants.ts
+++ b/src/electrum/constants.ts
@@ -1,28 +1,2 @@
 export const TEST_MNEMONIC =
 	'decorate grass round powder swarm syrup identify resemble mass online grunt cruise';
-export const TESTNET_PEERS = [
-	{
-		host: 'testnet.hsmiths.com',
-		ssl: 53012,
-		tcp: 53012,
-		protocol: 'ssl'
-	},
-	{
-		host: 'tn.not.fyi',
-		ssl: 55002,
-		tcp: 55002,
-		protocol: 'ssl'
-	},
-	{
-		host: 'testnet.aranguren.org',
-		ssl: 51002,
-		tcp: 51001,
-		protocol: 'ssl'
-	},
-	{
-		host: 'blackie.c3-soft.com',
-		ssl: 57006,
-		tcp: 57006,
-		protocol: 'ssl'
-	}
-];

--- a/tests/electrum.test.ts
+++ b/tests/electrum.test.ts
@@ -1,10 +1,14 @@
 import * as chai from 'chai';
+import net from 'net';
+import tls from 'tls';
+
 import { Wallet } from '../';
 import { EAvailableNetworks, EAddressType, IGetUtxosResponse } from '../src';
 import { TEST_MNEMONIC } from './constants';
 import { Result } from '../src';
 import { servers } from '../example/helpers';
 import { EXPECTED_SHARED_RESULTS } from './expected-results';
+
 const expect = chai.expect;
 
 const testTimeout = 60000;
@@ -18,7 +22,9 @@ before(async function () {
 		network: EAvailableNetworks.testnet,
 		addressType: EAddressType.p2wpkh,
 		electrumOptions: {
-			servers: servers[EAvailableNetworks.testnet]
+			servers: servers[EAvailableNetworks.testnet],
+			net,
+			tls
 		}
 	});
 	if (res.isErr()) {

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -1,5 +1,8 @@
 import * as chai from 'chai';
 import { validateMnemonic } from 'bip39';
+import net from 'net';
+import tls from 'tls';
+
 import { Wallet } from '../';
 import {
 	EAddressType,
@@ -32,7 +35,9 @@ before(async function () {
 			setData
 		},
 		electrumOptions: {
-			servers: servers[EAvailableNetworks.testnet]
+			servers: servers[EAvailableNetworks.testnet],
+			net,
+			tls
 		}
 	});
 	if (res.isErr()) {

--- a/tests/transaction.test.ts
+++ b/tests/transaction.test.ts
@@ -1,4 +1,7 @@
 import * as chai from 'chai';
+import net from 'net';
+import tls from 'tls';
+
 import {
 	decodeRawTransaction,
 	IPrivateKeyInfo,
@@ -22,7 +25,9 @@ before(async function () {
 		mnemonic: TRANSACTION_TEST_MNEMONIC,
 		network: EAvailableNetworks.testnet,
 		electrumOptions: {
-			servers: servers[EAvailableNetworks.testnet]
+			servers: servers[EAvailableNetworks.testnet],
+			net,
+			tls,
 		}
 	});
 	if (res.isErr()) {

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -1,5 +1,8 @@
 import * as chai from 'chai';
 import { validateMnemonic } from 'bip39';
+import net from 'net';
+import tls from 'tls';
+
 import {
 	filterAddressesObjForGapLimit,
 	IAddress,
@@ -36,7 +39,9 @@ before(async function () {
 		network: EAvailableNetworks.testnet,
 		addressType: EAddressType.p2wpkh,
 		electrumOptions: {
-			servers: servers[EAvailableNetworks.testnet]
+			servers: servers[EAvailableNetworks.testnet],
+			net,
+			tls
 		}
 	});
 	if (res.isErr()) {


### PR DESCRIPTION
`rn-electrum-client` doesn't really work with TLS in Nodejs environment, presumably because a certificate has to be setup (and passed), so I'm passing the electrum peer (with TCP) for tests directly. Also pass `net` & `tls` in tests after https://github.com/synonymdev/beignet/pull/64