### PR TITLE
fix: use separate gap-limit for change addresses

### DIFF
--- a/src/electrum/index.ts
+++ b/src/electrum/index.ts
@@ -302,12 +302,14 @@ export class Electrum {
 						addressValues = filterAddressesForGapLimit({
 							addresses: addressValues,
 							index: addressIndex,
-							gapLimitOptions: this._wallet.gapLimitOptions
+							gapLimitOptions: this._wallet.gapLimitOptions,
+							change: false
 						});
 						changeAddressValues = filterAddressesForGapLimit({
 							addresses: changeAddressValues,
 							index: changeAddressIndex,
-							gapLimitOptions: this._wallet.gapLimitOptions
+							gapLimitOptions: this._wallet.gapLimitOptions,
+							change: true
 						});
 					}
 					const utxoScriptHashes: IAddress[] = currentWallet.utxos;
@@ -515,7 +517,8 @@ export class Electrum {
 								...filterAddressesObjForGapLimit({
 									addresses: allAddresses,
 									index: lowestAddressIndex,
-									gapLimitOptions: this._wallet.gapLimitOptions
+									gapLimitOptions: this._wallet.gapLimitOptions,
+									change: false
 								})
 							};
 							changeAddresses = {
@@ -523,7 +526,8 @@ export class Electrum {
 								...filterAddressesObjForGapLimit({
 									addresses: allChangeAddresses,
 									index: lowestChangeAddressIndex,
-									gapLimitOptions: this._wallet.gapLimitOptions
+									gapLimitOptions: this._wallet.gapLimitOptions,
+									change: true
 								})
 							};
 							break;
@@ -830,7 +834,8 @@ export class Electrum {
 					const addressesInRangeToSubscribe = filterAddressesForGapLimit({
 						addresses: Object.values(addresses),
 						index: addressIndex,
-						gapLimitOptions: this._wallet.gapLimitOptions
+						gapLimitOptions: this._wallet.gapLimitOptions,
+						change: false
 					});
 					const _scriptHashes = addressesInRangeToSubscribe.map(
 						(address) => address.scriptHash

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -62,4 +62,6 @@ export type TGetTotalFeeObj = {
 export type TGapLimitOptions = {
 	lookAhead: number;
 	lookBehind: number;
+	lookAheadChange: number;
+	lookBehindChange: number;
 };

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -358,13 +358,21 @@ export const getTxFee = ({
 export const filterAddressesForGapLimit = ({
 	addresses,
 	index,
-	gapLimitOptions
+	gapLimitOptions,
+	change
 }: {
 	addresses: IAddress[];
 	index: number;
 	gapLimitOptions: TGapLimitOptions;
+	change: boolean;
 }): IAddress[] => {
-	const { lookBehind, lookAhead } = gapLimitOptions;
+	const lookBehind = change
+		? gapLimitOptions.lookBehindChange
+		: gapLimitOptions.lookBehind;
+	const lookAhead = change
+		? gapLimitOptions.lookAheadChange
+		: gapLimitOptions.lookAhead;
+
 	return addresses.filter((a) => {
 		if (a.index >= index) {
 			return getAddressIndexDiff(index, a.index) <= lookAhead;
@@ -376,13 +384,21 @@ export const filterAddressesForGapLimit = ({
 export const filterAddressesObjForGapLimit = ({
 	addresses,
 	index,
-	gapLimitOptions
+	gapLimitOptions,
+	change
 }: {
 	addresses: IAddresses;
 	index: number;
 	gapLimitOptions: TGapLimitOptions;
+	change: boolean;
 }): IAddresses => {
-	const { lookBehind, lookAhead } = gapLimitOptions;
+	const lookBehind = change
+		? gapLimitOptions.lookBehindChange
+		: gapLimitOptions.lookBehind;
+	const lookAhead = change
+		? gapLimitOptions.lookAheadChange
+		: gapLimitOptions.lookAhead;
+
 	const response: IAddresses = {};
 	Object.values(addresses).map((a) => {
 		if (a.index >= index) {

--- a/src/wallet/constants.ts
+++ b/src/wallet/constants.ts
@@ -11,6 +11,7 @@ export const GENERATE_ADDRESS_AMOUNT = 5;
 
 // TODO: Add this as a settings for users to adjust when needed.
 export const GAP_LIMIT = 20;
+export const GAP_LIMIT_CHANGE = 20;
 
 export const DUST_LIMITS = {
 	[EAddressType.p2pkh]: 546,

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -177,7 +177,9 @@ describe('Wallet Library', async function () {
 	it('Should return addresses in range of the provided gap limit', async () => {
 		const gapLimitOptions = {
 			lookAhead: 2,
-			lookBehind: 2
+			lookBehind: 2,
+			lookAheadChange: 1,
+			lookBehindChange: 1
 		};
 		const addressesObj = wallet.data.addresses[EAddressType.p2wpkh];
 		const addresses: IAddress[] = Object.values(addressesObj);
@@ -190,7 +192,8 @@ describe('Wallet Library', async function () {
 		const filteredAddresses = filterAddressesForGapLimit({
 			addresses,
 			index,
-			gapLimitOptions
+			gapLimitOptions,
+			change: false
 		});
 		let indexes = filteredAddresses.map((a) => a.index);
 		let minIndex = Math.min(...indexes);
@@ -202,7 +205,8 @@ describe('Wallet Library', async function () {
 		const filteredAddressesObj = filterAddressesObjForGapLimit({
 			addresses: addressesObj,
 			index,
-			gapLimitOptions
+			gapLimitOptions,
+			change: false
 		});
 		indexes = Object.values(filteredAddressesObj).map((a: IAddress) => a.index);
 		minIndex = Math.min(...indexes);


### PR DESCRIPTION
- add `lookAheadChange` and `lookBehindChange` to the gapLimitOptions
- use gap limit of 10 for change when restoring a wallet