### PR TITLE
feat: add additionalAddresses param to refreshWallet

### DIFF
--- a/example/helpers.ts
+++ b/example/helpers.ts
@@ -69,7 +69,7 @@ export const servers = {
 			host: 'testnet.aranguren.org',
 			ssl: 51002,
 			tcp: 51001,
-			protocol: EProtocol.tcp,
+			protocol: EProtocol.tcp
 		}
 	],
 	[EAvailableNetworks.regtest]: [

--- a/src/electrum/index.ts
+++ b/src/electrum/index.ts
@@ -41,6 +41,7 @@ import {
 import {
 	err,
 	filterAddressesForGapLimit,
+	filterAddressesObjForAddressesList,
 	filterAddressesObjForGapLimit,
 	filterAddressesObjForSingleIndex,
 	filterAddressesObjForStartingIndex,
@@ -447,18 +448,21 @@ export class Electrum {
 	 * @param {number} addressIndex
 	 * @param {number} changeAddressIndex
 	 * @param {EAddressType[]} [addressTypesToCheck]
+	 * @additionalAddresses {string[]} [additionalAddresses]
 	 * @returns {Promise<Result<IGetUtxosResponse>>}
 	 */
 	async getUtxos({
 		scanningStrategy = EScanningStrategy.gapLimit,
 		addressIndex,
 		changeAddressIndex,
-		addressTypesToCheck = this._wallet.addressTypesToMonitor
+		addressTypesToCheck = this._wallet.addressTypesToMonitor,
+		additionalAddresses = []
 	}: {
 		scanningStrategy?: EScanningStrategy;
 		addressIndex?: number;
 		changeAddressIndex?: number;
 		addressTypesToCheck?: EAddressType[];
+		additionalAddresses?: string[];
 	}): Promise<Result<IGetUtxosResponse>> {
 		try {
 			if (!this.connectedToElectrum)
@@ -519,6 +523,10 @@ export class Electrum {
 									index: lowestAddressIndex,
 									gapLimitOptions: this._wallet.gapLimitOptions,
 									change: false
+								}),
+								...filterAddressesObjForAddressesList({
+									addresses: allAddresses,
+									additionalAddresses
 								})
 							};
 							changeAddresses = {
@@ -537,6 +545,10 @@ export class Electrum {
 								...filterAddressesObjForStartingIndex({
 									addresses: allAddresses,
 									index: lowestAddressIndex
+								}),
+								...filterAddressesObjForAddressesList({
+									addresses: allAddresses,
+									additionalAddresses
 								})
 							};
 							changeAddresses = {
@@ -553,6 +565,10 @@ export class Electrum {
 								...filterAddressesObjForSingleIndex({
 									addresses: allAddresses,
 									addressIndex: _addressIndex
+								}),
+								...filterAddressesObjForAddressesList({
+									addresses: allAddresses,
+									additionalAddresses
 								})
 							};
 							changeAddresses = {

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -442,6 +442,23 @@ export const filterAddressesObjForSingleIndex = ({
 	return response;
 };
 
+export const filterAddressesObjForAddressesList = ({
+	addresses,
+	additionalAddresses
+}: {
+	addresses: IAddresses;
+	additionalAddresses: string[];
+}): IAddresses => {
+	const response: IAddresses = {};
+	if (additionalAddresses.length === 0) {
+		return response;
+	}
+	Object.values(addresses).map((a) => {
+		if (additionalAddresses.includes(a.address)) response[a.scriptHash] = a;
+	});
+	return response;
+};
+
 /**
  * Removes dust utxos from an array of utxos.
  * @param {IUtxo[]} utxos

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -333,11 +333,16 @@ export class Wallet {
 	/**
 	 * Refreshes/Syncs the wallet data.
 	 * @param {boolean} [scanAllAddresses]
+	 * @param {string[]} [additionalAddresses]
 	 * @returns {Promise<Result<IWalletData>>}
 	 */
-	public async refreshWallet({ scanAllAddresses = false } = {}): Promise<
-		Result<IWalletData>
-	> {
+	public async refreshWallet({
+		scanAllAddresses = false,
+		additionalAddresses = []
+	}: {
+		scanAllAddresses?: boolean;
+		additionalAddresses?: string[];
+	} = {}): Promise<Result<IWalletData>> {
 		if (this.isRefreshing) {
 			return new Promise((resolve) => {
 				this._pendingRefreshPromises.push(resolve);
@@ -351,7 +356,8 @@ export class Wallet {
 				return this._handleRefreshError(r1.error.message);
 			}
 			const r2 = await this.getUtxos({
-				scanningStrategy: scanAllAddresses ? EScanningStrategy.all : undefined
+				scanningStrategy: scanAllAddresses ? EScanningStrategy.all : undefined,
+				additionalAddresses
 			});
 			if (r2.isErr()) {
 				return this._handleRefreshError(r2.error.message);
@@ -1734,12 +1740,14 @@ export class Wallet {
 		scanningStrategy = EScanningStrategy.gapLimit,
 		addressIndex,
 		changeAddressIndex,
-		addressTypesToCheck
+		addressTypesToCheck,
+		additionalAddresses = []
 	}: {
 		scanningStrategy?: EScanningStrategy;
 		addressIndex?: number;
 		changeAddressIndex?: number;
 		addressTypesToCheck?: EAddressType[];
+		additionalAddresses?: string[];
 	}): Promise<Result<IGetUtxosResponse>> {
 		const checkRes = await this.checkElectrumConnection();
 		if (checkRes.isErr()) return err(checkRes.error.message);
@@ -1747,7 +1755,8 @@ export class Wallet {
 			scanningStrategy,
 			addressIndex,
 			changeAddressIndex,
-			addressTypesToCheck
+			addressTypesToCheck,
+			additionalAddresses
 		});
 		if (getUtxosRes.isErr()) {
 			return err(getUtxosRes.error.message);

--- a/tests/transaction.test.ts
+++ b/tests/transaction.test.ts
@@ -27,7 +27,7 @@ before(async function () {
 		electrumOptions: {
 			servers: servers[EAvailableNetworks.testnet],
 			net,
-			tls,
+			tls
 		}
 	});
 	if (res.isErr()) {

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 
 import {
 	filterAddressesObjForGapLimit,
+	filterAddressesObjForAddressesList,
 	IAddress,
 	IAddresses,
 	Wallet
@@ -239,6 +240,22 @@ describe('Wallet Library', async function () {
 		expect(singleAddress.length).to.equal(1);
 		expect(minIndex).to.equal(5);
 		expect(maxIndex).to.equal(5);
+
+		const filteredAddressesList = filterAddressesObjForAddressesList({
+			addresses: addressesObj,
+			additionalAddresses: [
+				'tb1qhvc8wz32n6y3gxcw5dwdyq4ae5p83ur872shju', // path: m/84'/1'/0'/0/14
+				'tb1q7r8hpn4ymwxl8n9yjeluw6yda5rgjsw72pmmxy' // path: m/84'/1'/0'/0/15
+			]
+		});
+		indexes = Object.values(filteredAddressesList).map(
+			(a: IAddress) => a.index
+		);
+		minIndex = Math.min(...indexes);
+		maxIndex = Math.max(...indexes);
+		expect(indexes.length).to.equal(2);
+		expect(minIndex).to.equal(14);
+		expect(maxIndex).to.equal(15);
 	});
 
 	it('Should successfully return the private testnet key for a given path', async () => {


### PR DESCRIPTION
This PR adds new parameter `additionalAddresses` to `refreshWallet` function it allows you to specify list of addresses you want to re-scan, even if they are outside of gap limit. 