### PR TITLE
fix: fix test example

### DIFF
--- a/example/helpers.ts
+++ b/example/helpers.ts
@@ -61,7 +61,7 @@ export const servers = {
 			host: '35.187.18.233',
 			ssl: 8900,
 			tcp: 8911,
-			protocol: EProtocol.ssl
+			protocol: EProtocol.tcp
 		}
 	],
 	[EAvailableNetworks.testnet]: [

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,6 +1,8 @@
 import { EAvailableNetworks, generateMnemonic, Wallet } from '../src';
 import { getData, onMessage, servers, setData } from './helpers';
 import * as repl from 'repl';
+import net from 'net';
+import tls from 'tls';
 
 const network: EAvailableNetworks = EAvailableNetworks.mainnet;
 
@@ -15,11 +17,15 @@ const runExample = async (mnemonic = generateMnemonic()): Promise<void> => {
 			setData
 		},
 		electrumOptions: {
+			net,
+			tls,
 			servers: servers[network]
 		},
 		gapLimitOptions: {
 			lookAhead: 5,
-			lookBehind: 5
+			lookBehind: 5,
+			lookAheadChange: 5,
+			lookBehindChange: 5
 		}
 	});
 	if (createWalletResponse.isErr()) return;


### PR DESCRIPTION
This PR:
- Defaults test example to use tcp.
- Adds required params in example setup.

Running `npm run example` should now work as expected.