### PR TITLE
fix: do not wait for refresh to finish on wallet create

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beignet",
-  "version": "0.0.45",
+  "version": "0.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beignet",
-      "version": "0.0.45",
+      "version": "0.0.47",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -273,8 +273,7 @@ export class Wallet {
 			const res = await wallet.setWalletData();
 			if (res.isErr()) return err(res.error.message);
 			wallet.updateFeeEstimates(true);
-			console.log('Syncing Wallet...');
-			await wallet.refreshWallet({});
+			wallet.refreshWallet({});
 			if (wallet._disableMessagesOnCreate) wallet.disableMessages = false;
 			return ok(wallet);
 		} catch (e) {

--- a/tests/boost.test.ts
+++ b/tests/boost.test.ts
@@ -76,6 +76,7 @@ beforeEach(async function () {
 		throw res.error;
 	}
 	wallet = res.value;
+	await wallet.refreshWallet({});
 });
 
 describe('Boost', async function () {

--- a/tests/electrum.test.ts
+++ b/tests/electrum.test.ts
@@ -13,7 +13,7 @@ const expect = chai.expect;
 
 const testTimeout = 60000;
 
-let wallet;
+let wallet: Wallet;
 
 before(async function () {
 	this.timeout(testTimeout);
@@ -33,6 +33,7 @@ before(async function () {
 		return;
 	}
 	wallet = res.value;
+	await wallet.refreshWallet({});
 });
 
 describe('Electrum Methods', async function (): Promise<void> {
@@ -40,6 +41,7 @@ describe('Electrum Methods', async function (): Promise<void> {
 	it('connectToElectrum: Should connect to a random Electrum server', async () => {
 		const connectResponse = await wallet.connectToElectrum();
 		expect(connectResponse.isErr()).to.equal(false);
+		if (connectResponse.isErr()) return;
 		expect(connectResponse.value).to.equal('Connected to Electrum server.');
 	});
 

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -19,7 +19,7 @@ const expect = chai.expect;
 
 const testTimeout = 60000;
 
-let wallet;
+let wallet: Wallet;
 const WALLET_NAME = 'storagetestwallet0';
 
 before(async function () {

--- a/tests/transaction.test.ts
+++ b/tests/transaction.test.ts
@@ -17,7 +17,7 @@ const expect = chai.expect;
 
 const testTimeout = 60000;
 
-let wallet;
+let wallet: Wallet;
 
 before(async function () {
 	this.timeout(testTimeout);
@@ -35,6 +35,7 @@ before(async function () {
 		return;
 	}
 	wallet = res.value;
+	await wallet.refreshWallet({});
 });
 
 describe('Transaction Test', async function (): Promise<void> {
@@ -158,7 +159,11 @@ describe('Transaction Test', async function (): Promise<void> {
 		await wallet.transaction.resetSendTransaction();
 		const setupResponse = await wallet.transaction.setupTransaction({
 			outputs: [
-				{ address: 'tb1qaq7jszepjuntxx494xhwrxs746v94583ls02ke', value: 5000 }
+				{
+					index: 0,
+					address: 'tb1qaq7jszepjuntxx494xhwrxs746v94583ls02ke',
+					value: 5000
+				}
 			]
 		});
 		expect(setupResponse.isErr()).to.equal(false);

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -52,6 +52,7 @@ before(async function () {
 		return;
 	}
 	wallet = res.value;
+	await wallet.refreshWallet({});
 });
 
 describe('Wallet Library', async function () {


### PR DESCRIPTION
Doing a refresh in the create function details function for an unpredictable amount of time. It is better to just trigger the refresh but not wait for it.