### PR TITLE
fix: update fee on every wallet refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beignet",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beignet",
-      "version": "0.0.47",
+      "version": "0.0.48",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -274,7 +274,6 @@ export class Wallet {
 			if (res.isErr()) return err(res.error.message);
 			wallet.updateFeeEstimates(true);
 			wallet.refreshWallet({});
-			if (wallet._disableMessagesOnCreate) wallet.disableMessages = false;
 			return ok(wallet);
 		} catch (e) {
 			return err(e);
@@ -380,6 +379,8 @@ export class Wallet {
 			} else {
 				return this._handleRefreshError(e);
 			}
+		} finally {
+			if (this._disableMessagesOnCreate) this.disableMessages = false;
 		}
 	}
 


### PR DESCRIPTION
- new Blocktank api url
- do not fall to defaultFeesShape if both mempool and BT are not available
- force refresh if fees are older than 5 minules
- validate BT and mempool respose structure