### PR TITLE
feat: add wallet stop method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beignet",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beignet",
-      "version": "0.0.48",
+      "version": "0.0.49",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -281,6 +281,28 @@ export class Wallet {
 		}
 	}
 
+	/**
+	 * Stops the wallet. Use this method to prepare the wallet to be de
+	 * @returns {Promise<Result<string>>}
+	 */
+	public async stop(): Promise<Result<string>> {
+		try {
+			// if we are refreshing, we need to wait for it to finish
+			if (this.isRefreshing) {
+				await this.refreshWallet();
+			}
+			// disable onMessage callback
+			this.disableMessages = true;
+			// disable saving to storage
+			this._setData = undefined;
+			// disconnect from Electrum
+			await this.electrum.disconnect();
+			return ok('Wallet stopped.');
+		} catch (e) {
+			return err(e);
+		}
+	}
+
 	public async switchNetwork(
 		network: EAvailableNetworks,
 		servers?: TServer | TServer[]

--- a/tests/boost.test.ts
+++ b/tests/boost.test.ts
@@ -10,7 +10,7 @@ import {
 	EProtocol,
 	generateMnemonic,
 	Wallet
-} from '../src';
+} from '../';
 import {
 	bitcoinURL,
 	electrumHost,

--- a/tests/receive.test.ts
+++ b/tests/receive.test.ts
@@ -10,7 +10,7 @@ import {
 	generateMnemonic,
 	sleep,
 	Wallet
-} from '../src';
+} from '../';
 import {
 	bitcoinURL,
 	electrumHost,


### PR DESCRIPTION
Depends on #85

Adds the wallet.stop() method that should be used to prepare the wallet to be destroyed / replaced
- stops electrum
- replaces setData with undefined to prevent wallet saving any data
- sets disableMessages to false so that wallet does not emmit any messages using onMessage callback

tests included  
