### PR TITLE
feat: implement auto coin select

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ import { Wallet, generateMnemonic } from 'beignet';
 import net from 'net'
 import tls from 'tls'
 import { TStorage } from './wallet';
+import { ECoinSelectPreference } from "./transaction";
 
 // Generate a mnemonic phrase
 const mnemonic = generateMnemonic();
@@ -111,10 +112,10 @@ const passphrase = 'passphrase';
 
 // Connect to custom electrum server
 const servers: TServer = {
-	host: '35.233.47.252',
-	ssl: 18484,
-	tcp: 18483,
-	protocol: EProtocol.ssl,
+  host: '35.233.47.252',
+  ssl: 18484,
+  tcp: 18483,
+  protocol: EProtocol.ssl,
 };
 
 // Use a specific network (Defaults to mainnet)
@@ -128,8 +129,8 @@ const addressTypesToMonitor = [EAddressType.p2tr, EAddressType.p2wpkh];
 
 // Subscribe to server messages (TOnMessage)
 const onMessage: TOnMessage = (id, data) => {
-	console.log(id);
-	console.dir(data, { depth: null });
+  console.log(id);
+  console.dir(data, { depth: null });
 }
 
 // Disable startup messages. Messages resume once startup is complete. (Defaults to false)
@@ -137,34 +138,38 @@ const disableMessagesOnCreate = true;
 
 // Persist sessions by getting and setting data from storage
 const storage: TStorage = {
-	async getData<K extends keyof IWalletData>(
-		key: string
-	): Promise<Result<IWalletData[K]>> {
-		// Add your logic here
-	},
-	async setData<K extends keyof IWalletData>(
-		key: string,
-		value: IWalletData[K]
-	): Promise<Result<boolean>> {
-		// Add your logic here
-	}
+  async getData<K extends keyof IWalletData>(
+    key: string
+  ): Promise<Result<IWalletData[K]>> {
+    // Add your logic here
+  },
+  async setData<K extends keyof IWalletData>(
+    key: string,
+    value: IWalletData[K]
+  ): Promise<Result<boolean>> {
+    // Add your logic here
+  }
 };
+
+// Set the auto coin selection preference. (Defaults to ECoinSelectPreference.consolidate)
+const coinSelectPreference = ECoinSelectPreference.small;
 
 // Create a wallet instance
 const createWalletRes = await Wallet.create({
-	mnemonic,
-	passphrase,
-	electrumOptions: {
-		servers,
-		net,
-		tls
-	},
-	network,
-	onMessage,
-	storage, 
-    addressType,
-	addressTypesToMonitor,
-	disableMessagesOnCreate
+  mnemonic,
+  passphrase,
+  electrumOptions: {
+    servers,
+    net,
+    tls
+  },
+  network,
+  onMessage,
+  storage,
+  addressType,
+  addressTypesToMonitor,
+  disableMessagesOnCreate,
+  coinSelectPreference
 });
 if (createWalletRes.isErr()) return;
 const wallet = createWalletRes.value;
@@ -174,18 +179,18 @@ const utxos = wallet.listUtxos();
 
 // Send sats to multiple outputs
 const txs = [
-	{ address: 'address1', amount: 1000 },
-	{ address: 'address2', amount: 2000 },
-	{ address: 'address3', amount: 3000 },
+  { address: 'address1', amount: 1000 },
+  { address: 'address2', amount: 2000 },
+  { address: 'address3', amount: 3000 },
 ];
 const sendManyRes = await wallet.sendMany({ txs });
 
 // Sweep from a private key
 const sweepPrivateKeyRes = await wallet.sweepPrivateKey({
-	privateKey: 'privateKey',
-	toAddress: 'toAddress',
-	satsPerByte: 5,
-	broadcast: false
+  privateKey: 'privateKey',
+  toAddress: 'toAddress',
+  satsPerByte: 5,
+  broadcast: false
 });
 
 // Get tx history for a given address. { tx_hash: string; height: number; }[]

--- a/example/helpers.ts
+++ b/example/helpers.ts
@@ -77,7 +77,7 @@ export const servers = {
 			host: '35.233.47.252',
 			ssl: 18484,
 			tcp: 18483,
-			protocol: EProtocol.ssl
+			protocol: EProtocol.tcp
 		}
 	]
 };

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,4 +1,9 @@
-import { EAvailableNetworks, generateMnemonic, Wallet } from '../src';
+import {
+	EAvailableNetworks,
+	ECoinSelectPreference,
+	generateMnemonic,
+	Wallet
+} from '../src';
 import { getData, onMessage, servers, setData } from './helpers';
 import * as repl from 'repl';
 import net from 'net';
@@ -26,7 +31,8 @@ const runExample = async (mnemonic = generateMnemonic()): Promise<void> => {
 			lookBehind: 5,
 			lookAheadChange: 5,
 			lookBehindChange: 5
-		}
+		},
+		coinSelectPreference: ECoinSelectPreference.small
 	});
 	if (createWalletResponse.isErr()) return;
 	const wallet = createWalletResponse.value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beignet",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beignet",
-      "version": "0.0.51",
+      "version": "0.0.52",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -1,4 +1,11 @@
-import { IOutput, ISendTransaction, IUtxo, IVin, IVout } from './wallet';
+import {
+	EAddressType,
+	IOutput,
+	ISendTransaction,
+	IUtxo,
+	IVin,
+	IVout
+} from './wallet';
 import { BIP32Interface } from 'bip32';
 import { Psbt } from 'bitcoinjs-lib';
 import { Result } from '../utils';
@@ -7,6 +14,7 @@ import { ECPairInterface } from 'ecpair';
 export interface ICreateTransaction {
 	transactionData?: ISendTransaction;
 	shuffleOutputs?: boolean;
+	runCoinSelect?: boolean;
 }
 
 export interface IAddInput {
@@ -65,3 +73,26 @@ export type TGapLimitOptions = {
 	lookAheadChange: number;
 	lookBehindChange: number;
 };
+
+export enum ECoinSelectPreference {
+	small = 'small',
+	large = 'large',
+	consolidate = 'consolidate',
+	firstInFirstOut = 'firstInFirstOut',
+	lastInFirstOut = 'lastInFirstOut'
+}
+
+export interface ICoinSelectResponse {
+	fee: number;
+	inputs: IUtxo[];
+	outputs: IOutput[];
+}
+
+export interface IAddressTypesIO {
+	inputs: {
+		[key in EAddressType]: number;
+	};
+	outputs: {
+		[key in EAddressType]: number;
+	};
+}

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -8,7 +8,7 @@ import {
 	TTxResult,
 	Tls
 } from './electrum';
-import { EFeeId, TGapLimitOptions } from './transaction';
+import { ECoinSelectPreference, EFeeId, TGapLimitOptions } from './transaction';
 import { ECPairInterface } from 'ecpair';
 import { BIP32Interface } from 'bip32';
 
@@ -189,6 +189,7 @@ export interface IWallet {
 	passphrase?: string;
 	network?: EAvailableNetworks;
 	addressType?: EAddressType;
+	coinSelectPreference?: ECoinSelectPreference;
 	data?: IWalletData;
 	storage?: TStorage;
 	electrumOptions: {

--- a/tests/transaction.test.ts
+++ b/tests/transaction.test.ts
@@ -6,7 +6,11 @@ import {
 	decodeRawTransaction,
 	IPrivateKeyInfo,
 	ISweepPrivateKeyRes,
-	Wallet
+	Wallet,
+	IUtxo,
+	IOutput,
+	ECoinSelectPreference,
+	Transaction
 } from '../';
 import { servers } from '../example/helpers';
 import { EAvailableNetworks, Result } from '../src';
@@ -188,5 +192,247 @@ describe('Transaction Test', async function (): Promise<void> {
 		expect(createTransaction.value.hex).to.equal(
 			'020000000001024b44d379e48a8100d1c26f7220b8bbf7a4894ff015d5bc4064a28d08d25d808d0000000000ffffffffa501e33469d9c408f8825511ed98dfffc99625e003eb76b804ab4de61eb9f6490000000000ffffffff028813000000000000160014e83d280b219726b31aa5a9aee19a1eae985ad0f15aa7020000000000160014a6bd95db4dd6979189cad389daad006e236f4ba802483045022100abfaa0cde11801d6fa70f1d7a462d9b53d0424728dd4be184c350c9fa1024a6f022049b3d50457f4639330dd5a77597ced98956462c066ba42dc28f4790939b07ad0012102e86b90924963237c59e5389aab1cc5350c114549d1c5e7186a56ef33aea24ff902473044022051ce04d1be481bed6323a581a04b7798afd6d18808f9e147fcb17da9eef763a202203f9526411d968c775e606dbc92fea1610b65fdc6a32d7331a58d7631f97f41a1012103eb5e83e7992a936edb19b18e4743047ef0f7aba4f469d8d3da1a2f0c514c7dab00000000'
 		);
+	});
+});
+
+describe('Transaction CoinSelect Test', function (): void {
+	const testInputs: IUtxo[] = [
+		{
+			address: 'bc1qrmnjd99e52g8pgevmnv9970fyu6hcaw6ejz8yn',
+			index: 0,
+			path: "m/84'/0'/0'/0/0",
+			scriptHash:
+				'a532a02196ec5213c7c2add2ea1bd4ef8904ad7fa5d4886e7a634c44de4687da',
+			height: 750000,
+			tx_hash:
+				'7f3a06b2b842d5946f4737865bd42a9c9a4203d6f9c06d9e943139831c359cd4',
+			tx_pos: 1,
+			value: 10000,
+			publicKey:
+				'0374f4eac0a9f8de35e6d1fa6ab66c03f0c51c1dba8aa038c944ebce8398a3fe39'
+		},
+		{
+			address: 'bc1q5dtmqaadlw0cft5q698wm93rdkc7hqfn6nrgk0',
+			index: 1,
+			path: "m/84'/0'/0'/0/1",
+			scriptHash:
+				'b642a02196ec5213c7c2add2ea1bd4ef8904ad7fa5d4886e7a634c44de4687cc',
+			height: 750001,
+			tx_hash:
+				'8e4b06b2b842d5946f4737865bd42a9c9a4203d6f9c06d9e943139831c359ee5',
+			tx_pos: 0,
+			value: 20000,
+			publicKey:
+				'02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9'
+		},
+		{
+			address: 'bc1qurz0qnhsmaptexjcmh4k5q78fyq0nteafspcxf',
+			index: 2,
+			path: "m/84'/0'/0'/0/2",
+			scriptHash:
+				'c753a02196ec5213c7c2add2ea1bd4ef8904ad7fa5d4886e7a634c44de4687bb',
+			height: 750002,
+			tx_hash:
+				'9f5c06b2b842d5946f4737865bd42a9c9a4203d6f9c06d9e943139831c359ff6',
+			tx_pos: 2,
+			value: 30000,
+			publicKey:
+				'03cbcaa9c98c877a26977d00825c956a238e8dddfbd322cce4f74b0b5bd6ace4a7'
+		},
+		{
+			address: 'bc1qlupxcmlzdxu6dfu6ztakmpaysqx32azm7s9cu4',
+			index: 3,
+			path: "m/84'/0'/0'/0/3",
+			scriptHash:
+				'd864a02196ec5213c7c2add2ea1bd4ef8904ad7fa5d4886e7a634c44de4687aa',
+			height: 750003,
+			tx_hash:
+				'af6d06b2b842d5946f4737865bd42a9c9a4203d6f9c06d9e943139831c359gg7',
+			tx_pos: 1,
+			value: 40000,
+			publicKey:
+				'02d2b36900396c9282fa14628566582f206a5dd0bcc8d5e892611806cafb0301f0'
+		},
+		{
+			address: 'bc1qere9mw0pqamhpr7ucq5s0e39uxaansry30gpl2',
+			index: 4,
+			path: "m/84'/0'/0'/0/4",
+			scriptHash:
+				'e975a02196ec5213c7c2add2ea1bd4ef8904ad7fa5d4886e7a634c44de4687f9',
+			height: 750004,
+			tx_hash:
+				'bf7e06b2b842d5946f4737865bd42a9c9a4203d6f9c06d9e943139831c359hh8',
+			tx_pos: 0,
+			value: 50000,
+			publicKey:
+				'03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556'
+		}
+	];
+
+	const testOutputs: IOutput[] = [
+		{
+			address: 'bc1ququnvd7swf3s95ghtpuxn3rz3dyfhz99vplyv7',
+			value: 10000,
+			index: 0
+		}
+	];
+
+	this.timeout(testTimeout);
+
+	before(async function () {
+		this.timeout(testTimeout);
+		const res = await Wallet.create({
+			mnemonic: TRANSACTION_TEST_MNEMONIC,
+			network: EAvailableNetworks.testnet,
+			electrumOptions: {
+				servers: servers[EAvailableNetworks.testnet],
+				net,
+				tls
+			}
+		});
+		if (res.isErr()) throw res.error;
+		wallet = res.value;
+		await wallet.refreshWallet({});
+	});
+
+	const transaction = new Transaction({ wallet });
+
+	it('Should select smallest UTXOs first when using small preference', () => {
+		const result = transaction.autoCoinSelect({
+			inputs: testInputs,
+			outputs: testOutputs,
+			satsPerByte: 1,
+			coinSelectPreference: ECoinSelectPreference.small
+		});
+
+		expect(result.isOk()).to.be.true;
+		if (result.isOk()) {
+			const selectedInputs = result.value.inputs;
+			// We need at least two inputs because of fees
+			expect(selectedInputs).to.have.length.at.least(1);
+			// Verify the first selected input is the smallest one
+			expect(selectedInputs[0].value).to.equal(10000);
+		}
+	});
+
+	it('Should select largest UTXOs first when using large preference', () => {
+		const result = transaction.autoCoinSelect({
+			inputs: testInputs,
+			outputs: testOutputs,
+			satsPerByte: 1,
+			coinSelectPreference: ECoinSelectPreference.large
+		});
+
+		expect(result.isOk()).to.be.true;
+		if (result.isOk()) {
+			const selectedInputs = result.value.inputs;
+			expect(selectedInputs).to.have.length.at.least(1);
+			// Verify the first selected input is the largest one
+			expect(selectedInputs[0].value).to.equal(50000);
+		}
+	});
+
+	it('Should select oldest UTXOs first when using firstInFirstOut preference', () => {
+		const result = transaction.autoCoinSelect({
+			inputs: testInputs,
+			outputs: testOutputs,
+			satsPerByte: 1,
+			coinSelectPreference: ECoinSelectPreference.firstInFirstOut
+		});
+
+		expect(result.isOk()).to.be.true;
+		if (result.isOk()) {
+			const selectedInputs = result.value.inputs;
+			expect(selectedInputs).to.have.length.at.least(1);
+			// Verify the first selected input has the lowest height (oldest)
+			expect(selectedInputs[0].height).to.equal(750000);
+		}
+	});
+
+	it('Should select newest UTXOs first when using lastInFirstOut preference', () => {
+		const result = transaction.autoCoinSelect({
+			inputs: testInputs,
+			outputs: testOutputs,
+			satsPerByte: 1,
+			coinSelectPreference: ECoinSelectPreference.lastInFirstOut
+		});
+
+		expect(result.isOk()).to.be.true;
+		if (result.isOk()) {
+			const selectedInputs = result.value.inputs;
+			expect(selectedInputs).to.have.length.at.least(1);
+			// Verify the first selected input has the highest height (newest)
+			expect(selectedInputs[0].height).to.equal(750004);
+		}
+	});
+
+	it('Should select all UTXOs when using consolidate preference', () => {
+		const result = transaction.autoCoinSelect({
+			inputs: testInputs,
+			outputs: testOutputs,
+			satsPerByte: 1,
+			coinSelectPreference: ECoinSelectPreference.consolidate
+		});
+
+		expect(result.isOk()).to.be.true;
+		if (result.isOk()) {
+			const selectedInputs = result.value.inputs;
+			expect(selectedInputs).to.have.lengthOf(testInputs.length);
+			const totalValue = selectedInputs.reduce(
+				(sum, input) => sum + input.value,
+				0
+			);
+			expect(totalValue).to.equal(150000);
+		}
+	});
+
+	it('Should handle insufficient funds scenario', () => {
+		const largeOutput: IOutput[] = [
+			{
+				address: 'bc1ququnvd7swf3s95ghtpuxn3rz3dyfhz99vplyv7',
+				value: 1000000,
+				index: 0
+			}
+		];
+
+		const result = transaction.autoCoinSelect({
+			inputs: testInputs,
+			outputs: largeOutput,
+			satsPerByte: 1,
+			coinSelectPreference: ECoinSelectPreference.small
+		});
+
+		expect(result.isErr()).to.be.true;
+		if (result.isErr()) {
+			expect(result.error.message).to.equal('Not enough funds.');
+		}
+	});
+
+	it('Should handle fee calculation correctly', () => {
+		const result = transaction.autoCoinSelect({
+			inputs: testInputs,
+			outputs: testOutputs,
+			satsPerByte: 5,
+			coinSelectPreference: ECoinSelectPreference.small
+		});
+
+		expect(result.isOk()).to.be.true;
+		if (result.isOk()) {
+			expect(result.value.fee).to.be.greaterThan(0);
+		}
+	});
+
+	it('Should handle empty inputs scenario', () => {
+		const result = transaction.autoCoinSelect({
+			inputs: [],
+			outputs: testOutputs,
+			satsPerByte: 1,
+			coinSelectPreference: ECoinSelectPreference.small
+		});
+
+		expect(result.isErr()).to.be.true;
+		if (result.isErr()) {
+			expect(result.error.message).to.equal('No inputs provided');
+		}
 	});
 });


### PR DESCRIPTION
This PR:
- Adds and implements auto coin select functionality with the following options:
    - Consolidate (default)
        - Use all available UTXO's regardless of the amount being sent.
    - Large
        - Sort by and use largest UTXO's first.
    - Small
        - Sort by and use smallest UTXO's first.
    - First-In First-Out
        - Use older UTXO's first (by block height).
    - Last-In Last-Out
        - Use newer UTXO's first (by block height).
- Bumps version to `0.0.52`.
- Adds `coinSelectPreference` to example in `README.md`.