### PR TITLE
fix: electrum protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beignet",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beignet",
-      "version": "0.0.52",
+      "version": "0.0.53",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ecpair": "2.1.0",
         "lodash.clonedeep": "4.5.0",
         "net": "1.0.2",
-        "rn-electrum-client": "0.0.21"
+        "rn-electrum-client": "0.0.22"
       },
       "devDependencies": {
         "@types/chai": "4.3.0",
@@ -2684,9 +2684,10 @@
       }
     },
     "node_modules/rn-electrum-client": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/rn-electrum-client/-/rn-electrum-client-0.0.21.tgz",
-      "integrity": "sha512-UWImjAXwhezFF9KrA8mGCsz1gx14/afi36YWj+7YdSFWKy9ORRwjKdjcZWuWwCy7whn9AgU0gxOoUATWbH3nPA==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/rn-electrum-client/-/rn-electrum-client-0.0.22.tgz",
+      "integrity": "sha512-AOCkG5NtTqbiQ3GxyGIftoiDnxJ0itL8sptQE1vrdfplrfoayLpuoC/aCVv6OtedvGAvDXjKFs57qVek1arlAg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ecpair": "2.1.0",
     "lodash.clonedeep": "4.5.0",
     "net": "1.0.2",
-    "rn-electrum-client": "0.0.21"
+    "rn-electrum-client": "0.0.22"
   },
   "devDependencies": {
     "@types/chai": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beignet",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "A self-custodial, JS Bitcoin wallet management library.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/electrum/index.ts
+++ b/src/electrum/index.ts
@@ -137,6 +137,8 @@ export class Electrum {
 			return err('Regtest requires that you pre-specify a server.');
 		}
 		const startResponse = await electrum.start({
+			clientName: 'beignet',
+			protocolVersion: '1.4',
 			network: electrumNetwork,
 			net: this.net,
 			tls: this.tls,


### PR DESCRIPTION
Follow up from https://github.com/synonymdev/react-native-electrum-client/pull/28. Passes client name and protocol version to `react-native-electrum-client`.